### PR TITLE
Rebrand pipe end from /dev/redeem/

### DIFF
--- a/configs/default.cfg
+++ b/configs/default.cfg
@@ -8,7 +8,7 @@ ui = /etc/toggle/style/Plain/ui_1920x1080.json
 plate = /etc/toggle/platforms/prusa_i3.stl
 probe-point = /etc/toggle/probe-point.stl
 model_folder = /usr/share/models
-message_fd = /dev/toggle_1
+message_fd = /dev/redeem/toggle
 
 angle_min = -50
 angle_max = 50


### PR DESCRIPTION
This is a resubmission of PR#15 against Toggle's current development branch

Note that this change MUST be coordinated with
corresponding changes to the pipe handler in Redeem and the configuration file for OctoPrint.

This renaming is introduced in the “BoxingDay” image. (Dec 2018)