### PR TITLE
Prepare to release Toggle 1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ VCS = git
 style = pep440-branch-based
 versionfile_source = toggle/_version.py
 versionfile_build = toggle/_version.py
-tag_prefix = base_
+tag_prefix = v
 parentdir_prefix =
 
 [yapf]

--- a/toggle/Toggle.py
+++ b/toggle/Toggle.py
@@ -100,8 +100,8 @@ class Toggle:
     if level > 0:
       logging.getLogger().setLevel(level)
 
-    sys.stdout = LoggerWriter(config, logging, 20)
-    sys.stderr = LoggerWriter(config, logging, 50)
+    sys.stdout = LoggerWriter(config, logging, logging.INFO)
+    sys.stderr = LoggerWriter(config, logging, logging.FATAL)
 
     Clutter.init(None)
 

--- a/toggle/__init__.py
+++ b/toggle/__init__.py
@@ -1,7 +1,11 @@
-#! -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 __url__ = "https://github.com/intelligent-agent/toggle"
 
 from ._version import get_versions
 __long_version__ = get_versions()['version']
-__version__ = __long_version__.split('+')[0]
-del get_versions
+try:
+  __version__ = __long_version__.split('+')[0] + '-' + __long_version__.split('+')[1].split('.')[0]
+except:
+  __version__ = __long_version__.split('+')[0]
+finally:
+  del get_versions

--- a/toggle/_version.py
+++ b/toggle/_version.py
@@ -39,7 +39,7 @@ def get_config():
   cfg = VersioneerConfig()
   cfg.VCS = "git"
   cfg.style = "pep440-branch-based"
-  cfg.tag_prefix = "base_"
+  cfg.tag_prefix = "v"
   cfg.parentdir_prefix = ""
   cfg.versionfile_source = "toggle/_version.py"
   cfg.verbose = False


### PR DESCRIPTION
The change to the versioning is to base the version number on the latest tagged release along this line.

The other changes are just cosmetic