### PR TITLE
Fix RestClient.login() against OctoPrint's CSRF-protected /api/login

### DIFF
--- a/toggle/core/RestClient.py
+++ b/toggle/core/RestClient.py
@@ -18,11 +18,29 @@ class RestClient:
     self._headers = {'Content-Type': 'application/json', 'X-Api-Key': self._api_key}
 
   def login(self):
-    url = self._build_url("login")
+    # OctoPrint protects /api/login with a double-submit CSRF cookie:
+    # a GET to any page sets a csrf_token_* cookie, and the same value
+    # must be echoed back as X-CSRF-Token on the POST, or it's
+    # rejected with 400 "CSRF validation failed" regardless of
+    # credentials. Use a Session so the cookie set here is
+    # automatically resent (under its real, port-suffixed name) below.
     user = self.config.get("OctoPrint", "user")
     password = self.config.get("OctoPrint", "password")
     data = json.dumps({'user': user, 'pass': password})
-    r = requests.post(url, data=data, headers={'Content-Type': 'application/json'})
+    session = requests.Session()
+    try:
+      session.get(f"http://{self._host}:{self._port}/")
+    except requests.ConnectionError:
+      logging.warning("Authentication failed! Check username and password + CORS")
+      return "INVALID-SESSION"
+    csrf_token = next(
+      (v for k, v in session.cookies.items() if k.startswith("csrf_token")),
+      None
+    )
+    headers = {'Content-Type': 'application/json'}
+    if csrf_token:
+      headers['X-CSRF-Token'] = csrf_token
+    r = session.post(self._build_url("login"), data=data, headers=headers)
     if r.status_code == 200:
       return r.json()["session"]
     else:


### PR DESCRIPTION
## Problem

Toggle can't connect to OctoPrint at all - stuck forever on "Authenticating..." on the touchscreen, with the log spamming:

```
WARNING  Authentication failed! Check username and password + CORS
```

`RestClient.login()`'s `on_connected_cb()` caller retries this in an infinite loop, so this isn't a degraded state - Toggle never gets past the very first step.

## Root cause

OctoPrint added CSRF protection to `/api/login` a while back (confirmed present on 1.11.8, likely earlier too). It's a double-submit cookie scheme: a GET to any page sets a `csrf_token_*` cookie (name is port-suffixed), and a POST that changes state must echo that same value back as an `X-CSRF-Token` header, or OctoPrint responds `400 {"error": "CSRF validation failed"}` - regardless of whether the username/password are correct.

`login()` was doing a bare POST with no cookie/CSRF handling at all, so it always failed this check.

## Fix

- Do a GET to the root page first, via a `requests.Session()` so the cookie set on that response is captured.
- Pull the cookie value (matched by name prefix `csrf_token`, since the real name is port-suffixed - e.g. `csrf_token_P5000`).
- Send it as `X-CSRF-Token` on the login POST, over the same session (so the cookie itself gets resent too, under its real name).

## Test plan

- [x] Reproduced against a live OctoPrint 1.11.8 instance: confirmed `curl -X POST /api/login` with credentials alone gets `400 CSRF validation failed`, and with the GET+cookie+header dance gets `200` with a valid session.
- [x] Deployed the patched `RestClient.py` onto a live Recore board running Toggle + OctoPrint 1.11.8 - the "Authentication failed" log spam stopped, `journalctl -u toggle` went quiet after "Toggle ready", and the touchscreen UI came up connected instead of stuck on the auth screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)